### PR TITLE
CLOUDP-47518: Adjust cluster name normalization to safer length

### DIFF
--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -195,10 +195,14 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details br
 }
 
 // NormalizeClusterName will sanitize a name to make sure it will be accepted
-// by the Atlas API. Atlas requires cluster names to be 30 characters or less.
+// by the Atlas API. Atlas has different name length requirements depending on
+// which environment it's running in. A length of 23 is a safe choice and
+// truncates UUIDs nicely.
 func NormalizeClusterName(name string) string {
-	if len(name) > 30 {
-		return string(name[0:30])
+	const maximumNameLength = 23
+
+	if len(name) > maximumNameLength {
+		return string(name[0:maximumNameLength])
 	}
 
 	return name


### PR DESCRIPTION
Atlas places different restrictions on cluster name length depending on which environment it is running in. We need to truncate to a sane length that will be safe for most.

With this PR we are switching to a cluster name length of 23. This truncates UUIDs nicely after the fourth group of characters.