### PR TITLE
CLOUDP-47296: Add help flag

### DIFF
--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -52,7 +52,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          ./scripts/build-production-binary.sh ${version} artifacts/atlas-service-broker-linux-arm64-${version}
+          ./scripts/build-production-binary.sh artifacts/atlas-service-broker-linux-arm64-${version}
   "setup_hub":
     - command: shell.exec
       params:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -52,7 +52,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          ./scripts/build-production-binary.sh artifacts/atlas-service-broker-linux-arm64-${version}
+          ./scripts/build-production-binary.sh ${version} artifacts/atlas-service-broker-linux-arm64-${version}
   "setup_hub":
     - command: shell.exec
       params:

--- a/main.go
+++ b/main.go
@@ -32,12 +32,25 @@ const (
 func main() {
 	// Add --help and -h flag.
 	helpDescription := "Print information about the MongoDB Atlas Service Broker and helpful links."
-	help := flag.Bool("help", false, helpDescription)
-	flag.BoolVar(help, "h", false, helpDescription)
+	helpFlag := flag.Bool("help", false, helpDescription)
+	flag.BoolVar(helpFlag, "h", false, helpDescription)
+
+	// Add --version and -v flag.
+	versionDescription := "Print current version of MongoDB Atlas Service Broker."
+	versionFlag := flag.Bool("version", false, versionDescription)
+	flag.BoolVar(versionFlag, "v", false, versionDescription)
+
+	flag.Parse()
 
 	// Output help message if help flag was specified.
-	if flag.Parse(); *help {
+	if *helpFlag {
 		fmt.Println(getHelpMessage())
+		return
+	}
+
+	// Output current version if version flag was specified.
+	if *versionFlag {
+		fmt.Println(version)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -29,6 +30,29 @@ const (
 )
 
 func main() {
+	help := flag.Bool("help", false, "")
+	flag.Parse()
+
+	// Output help message if help flag was specified.
+	if *help {
+		fmt.Println(getHelpMessage())
+		return
+	}
+
+	startBrokerServer()
+}
+
+func getHelpMessage() string {
+	const helpMessage = `MongoDB Atlas Service Broker %s
+
+This is a Service Broker which provides access to MongoDB deployments running
+in MongoDB Atlas. It conforms to the Open Service Broker specification and can
+be used with any compatible platform, such as the Kubernetes Service Catalog.`
+
+	return fmt.Sprintf(helpMessage, version)
+}
+
+func startBrokerServer() {
 	logLevel := getEnvOrDefault("BROKER_LOG_LEVEL", DefaultLogLevel)
 	logger, err := createLogger(logLevel)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,11 +30,13 @@ const (
 )
 
 func main() {
-	help := flag.Bool("help", false, "")
-	flag.Parse()
+	// Add --help and -h flag.
+	helpDescription := "Print information about the MongoDB Atlas Service Broker and helpful links."
+	help := flag.Bool("help", false, helpDescription)
+	flag.BoolVar(help, "h", false, helpDescription)
 
 	// Output help message if help flag was specified.
-	if *help {
+	if flag.Parse(); *help {
 		fmt.Println(getHelpMessage())
 		return
 	}
@@ -49,7 +51,7 @@ This is a Service Broker which provides access to MongoDB deployments running
 in MongoDB Atlas. It conforms to the Open Service Broker specification and can
 be used with any compatible platform, for example the Kubernetes Service Catalog.
 
-For instructions on how to install and use the service broker please refer to
+For instructions on how to install and use the Service Broker please refer to
 the documentation: https://docs.mongodb.com/atlas-open-service-broker
 
 Github: https://github.com/mongodb/mongodb-atlas-service-broker

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-// releaseVersion should be set by the linker at compile time
+// releaseVersion should be set by the linker at compile time.
 var releaseVersion = "development-build"
 
 // Default values for the configuration variables.
@@ -51,7 +51,7 @@ func main() {
 
 	// Output current version if version flag was specified.
 	if *versionFlag {
-		fmt.Println(version)
+		fmt.Println(releaseVersion)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,13 @@ func getHelpMessage() string {
 
 This is a Service Broker which provides access to MongoDB deployments running
 in MongoDB Atlas. It conforms to the Open Service Broker specification and can
-be used with any compatible platform, such as the Kubernetes Service Catalog.`
+be used with any compatible platform, for example the Kubernetes Service Catalog.
+
+For instructions on how to install and use the service broker please refer to
+the documentation: https://docs.mongodb.com/atlas-open-service-broker
+
+Github: https://github.com/mongodb/mongodb-atlas-service-broker
+Docker Image: quay.io/mongodb/mongodb-atlas-service-broker`
 
 	return fmt.Sprintf(helpMessage, version)
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
+const version = "0.1.0"
+
 // Default values for the configuration variables.
 const (
 	DefaultLogLevel = "INFO"
@@ -64,7 +66,7 @@ func main() {
 	// Mount broker server at the root.
 	http.Handle("/", brokerapi.New(broker, NewLagerZapLogger(logger), credentials))
 
-	logger.Infow("Starting API server ", "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
+	logger.Infow("Starting API server", "version", version, "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
 
 	// Start broker HTTP server.
 	if err = http.ListenAndServe(endpoint, nil); err != nil {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-const version = "0.1.0"
+// releaseVersion should be set by the linker at compile time
+var releaseVersion = "development-build"
 
 // Default values for the configuration variables.
 const (
@@ -70,7 +71,7 @@ the documentation: https://docs.mongodb.com/atlas-open-service-broker
 Github: https://github.com/mongodb/mongodb-atlas-service-broker
 Docker Image: quay.io/mongodb/mongodb-atlas-service-broker`
 
-	return fmt.Sprintf(helpMessage, version)
+	return fmt.Sprintf(helpMessage, releaseVersion)
 }
 
 func startBrokerServer() {
@@ -111,7 +112,7 @@ func startBrokerServer() {
 	// Mount broker server at the root.
 	http.Handle("/", brokerapi.New(broker, NewLagerZapLogger(logger), credentials))
 
-	logger.Infow("Starting API server", "version", version, "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
+	logger.Infow("Starting API server", "releaseVersion", releaseVersion, "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
 
 	// Start broker HTTP server.
 	if err = http.ListenAndServe(endpoint, nil); err != nil {

--- a/scripts/build-production-binary.sh
+++ b/scripts/build-production-binary.sh
@@ -3,14 +3,11 @@
 # Build a stripped, statically linked binary for linux/amd64
 # Must be called from repository root
 
-if [ -z "$1" ]; then
-  echo 'Usage: ./scripts/build-production-binary.sh OUTPUT_LOCATION' > /dev/stderr
+if [ -z "$2" ]; then
+  echo 'Usage: ./scripts/build-production-binary.sh VERSION OUTPUT_LOCATION' > /dev/stderr
   exit 1
 fi
 
 set -xeuf
 
-
-release_version=$(git describe --dirty)
-
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$release_version" -o "$1"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$1" -o "$2"

--- a/scripts/build-production-binary.sh
+++ b/scripts/build-production-binary.sh
@@ -3,11 +3,14 @@
 # Build a stripped, statically linked binary for linux/amd64
 # Must be called from repository root
 
-if [ -z "$2" ]; then
-  echo 'Usage: ./scripts/build-production-binary.sh VERSION OUTPUT_LOCATION' > /dev/stderr
+if [ -z "$1" ]; then
+  echo 'Usage: ./scripts/build-production-binary.sh OUTPUT_LOCATION' > /dev/stderr
   exit 1
 fi
 
 set -xeuf
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$1" -o "$2"
+
+release_version=$(git describe --dirty)
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$release_version" -o "$1"

--- a/scripts/build-production-binary.sh
+++ b/scripts/build-production-binary.sh
@@ -10,4 +10,7 @@ fi
 
 set -xeuf
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o "$1"
+
+release_version=$(git describe --dirty)
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$release_version" -o "$1"


### PR DESCRIPTION
Users can pass either a `--help` or `-h` flag to get a nice description (with the current version) of the broker with some helpful links. We should also add links to the third-party notices once they are available in the docs.