### PR TITLE
CLOUDP-47509: push tag for each image repo (latest & non-latest)

### DIFF
--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -65,7 +65,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN=${github}
+          export GITHUB_TOKEN=${github_token}
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -91,7 +91,7 @@ functions:
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
 
           docker push ${docker_repo}/${docker_name}:${version}
-          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
+          if [[ ${version} =~ [0-9]+.[0-9]+.[0-9]+$ ]]; then
             docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest
             docker push ${docker_repo}/${docker_name}:latest
           fi

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -56,7 +56,7 @@ functions:
   "setup_hub":
     - command: shell.exec
       params:
-        script: |
+        script: | 
           sudo pacman  --refresh --noconfirm -S hub
           echo "Installed Hub CLI"
   "publish_github_release":

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -39,7 +39,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           # Get version from tag on head and throw error if none exists
-          # Take the character v at the beginning of the string if any, and keep the rest
+          # Remove the character v at the beginning of the string if any, and keep the rest
           export VERSION=$(git tag -l --points-at HEAD | sed 's/^v\(.*\)/\1/')
           [[ -z "$VERSION" ]] && { echo "No version tag on HEAD" ; exit 1; }
 
@@ -92,8 +92,8 @@ functions:
 
           docker push ${docker_repo}/${docker_name}:${version}
           if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
-            docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest 
-            docker push ${docker_repo}/${docker_name}:latest 
+            docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest
+            docker push ${docker_repo}/${docker_name}:latest
           fi
 
 tasks:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -39,7 +39,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           # Get version from tag on head and throw error if none exists
-          export VERSION=$(git tag -l --points-at HEAD | sed 's/v//')
+          export VERSION=$(git tag -l --points-at HEAD | sed 's/^v\(.*\)/\1/')
           [[ -z "$VERSION" ]] && { echo "No version tag on HEAD" ; exit 1; }
 
           echo "version: \"$VERSION\"" > version_expansion.yaml
@@ -56,7 +56,7 @@ functions:
   "setup_hub":
     - command: shell.exec
       params:
-        script: | 
+        script: |
           sudo pacman  --refresh --noconfirm -S hub
           echo "Installed Hub CLI"
   "publish_github_release":
@@ -64,7 +64,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN=${github_token}
+          export GITHUB_TOKEN=8af0123063041586b4b9c501a4ad00190c56d192
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -81,14 +81,17 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          docker build . -t ${docker_repo}/${docker_name}:${version}
+          docker build . -t ${docker_repo}/${docker_name}:${version} # by default
+          docker build . -t ${docker_repo}/${docker_name}:$([[ ${version} =~ [0-9]+.[0-9]+$ ]] && echo "latest" || echo ${version})
   "publish_docker":
     - command: shell.exec
       params:
         working_dir: src/atlas-service-broker
         script: |
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
-          docker push ${docker_repo}/${docker_name}:${version}
+
+          docker push ${docker_repo}/${docker_name}:${version} # by default
+          docker push ${docker_repo}/${docker_name}:$([[ ${version} =~ [0-9]+.[0-9]+$ ]] && echo "latest" || echo ${version})
 
 tasks:
   - name: unit_tests
@@ -143,3 +146,4 @@ buildvariants:
     tasks:
       - release_github
       - release_docker
+

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -81,8 +81,12 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          docker build . -t ${docker_repo}/${docker_name}:${version} # by default
-          docker build . -t ${docker_repo}/${docker_name}:$([[ ${version} =~ [0-9]+.[0-9]+$ ]] && echo "latest" || echo ${version})
+          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
+            docker build . -t ${docker_repo}/${docker_name}:${version}
+            docker build . -t ${docker_repo}/${docker_name}:latest
+          else
+            docker build . -t ${docker_repo}/${docker_name}:${version}
+          fi
   "publish_docker":
     - command: shell.exec
       params:
@@ -90,8 +94,12 @@ functions:
         script: |
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
 
-          docker push ${docker_repo}/${docker_name}:${version} # by default
-          docker push ${docker_repo}/${docker_name}:$([[ ${version} =~ [0-9]+.[0-9]+$ ]] && echo "latest" || echo ${version})
+          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
+            docker push ${docker_repo}/${docker_name}:${version}
+            docker push ${docker_repo}/${docker_name}:latest
+          else
+            docker push ${docker_repo}/${docker_name}:${version}
+          fi
 
 tasks:
   - name: unit_tests
@@ -146,4 +154,3 @@ buildvariants:
     tasks:
       - release_github
       - release_docker
-

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -39,6 +39,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           # Get version from tag on head and throw error if none exists
+          # Take the character v at the beginning of the string if any, and keep the rest
           export VERSION=$(git tag -l --points-at HEAD | sed 's/^v\(.*\)/\1/')
           [[ -z "$VERSION" ]] && { echo "No version tag on HEAD" ; exit 1; }
 
@@ -64,7 +65,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN=8af0123063041586b4b9c501a4ad00190c56d192
+          export GITHUB_TOKEN=${github}
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -81,12 +82,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
-            docker build . -t ${docker_repo}/${docker_name}:${version}
-            docker build . -t ${docker_repo}/${docker_name}:latest
-          else
-            docker build . -t ${docker_repo}/${docker_name}:${version}
-          fi
+          docker build . -t ${docker_repo}/${docker_name}:${version}
   "publish_docker":
     - command: shell.exec
       params:
@@ -94,11 +90,10 @@ functions:
         script: |
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
 
+          docker push ${docker_repo}/${docker_name}:${version}
           if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
-            docker push ${docker_repo}/${docker_name}:${version}
-            docker push ${docker_repo}/${docker_name}:latest
-          else
-            docker push ${docker_repo}/${docker_name}:${version}
+            docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest 
+            docker push ${docker_repo}/${docker_name}:latest 
           fi
 
 tasks:


### PR DESCRIPTION
Noticeable changes:
- Adjusted regex (sed) for only removing the first v we encounter (if any) and keep the rest
- Script for building a single image, and pushing two different versions to the docker repo. This of course does depend on how its tagged. If a commit is tagged as `v0.0.1`, this will push two images to the docker repo. One with `latest` and one with `0.0.1` tag. Any other tagging format indicates not a latest and only 1 image is created and pushed to the docker repo.