### PR TITLE
Get version from git tag

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,8 @@ import (
 	"github.com/pivotal-cf/brokerapi"
 )
 
-const version = "0.1.0"
+// releaseVersion should be set by the linker at compile time
+var releaseVersion = "development-build"
 
 // Default values for the configuration variables.
 const (
@@ -57,7 +58,7 @@ the documentation: https://docs.mongodb.com/atlas-open-service-broker
 Github: https://github.com/mongodb/mongodb-atlas-service-broker
 Docker Image: quay.io/mongodb/mongodb-atlas-service-broker`
 
-	return fmt.Sprintf(helpMessage, version)
+	return fmt.Sprintf(helpMessage, releaseVersion)
 }
 
 func startBrokerServer() {
@@ -98,7 +99,7 @@ func startBrokerServer() {
 	// Mount broker server at the root.
 	http.Handle("/", brokerapi.New(broker, NewLagerZapLogger(logger), credentials))
 
-	logger.Infow("Starting API server", "version", version, "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
+	logger.Infow("Starting API server", "releaseVersion", releaseVersion, "host", host, "port", port, "atlas_base_url", baseURL, "group_id", groupID)
 
 	// Start broker HTTP server.
 	if err = http.ListenAndServe(endpoint, nil); err != nil {

--- a/scripts/build-production-binary.sh
+++ b/scripts/build-production-binary.sh
@@ -10,4 +10,7 @@ fi
 
 set -xeuf
 
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o "$1"
+
+release_version=$(git describe --dirty)
+
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w -X main.releaseVersion=$release_version" -o "$1"


### PR DESCRIPTION
This PR sets the version to be the value of the git tag. Also renamed `version` to `releaseVersion` for clarity.