### PR TITLE
Disable biConnector

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -38,7 +38,7 @@ func (lagerZapLogger *LagerZapLogger) Session(task string, data ...lager.Data) l
 }
 
 // WithData creates a new child with the parent fields and returns a logger with newly added data. We are currently
-// returing the same logger back.
+// returning the same logger back.
 func (lagerZapLogger *LagerZapLogger) WithData(data lager.Data) lager.Logger {
 	return lagerZapLogger
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/mongodb/mongodb-atlas-service-broker/pkg/atlas"
 	brokerlib "github.com/mongodb/mongodb-atlas-service-broker/pkg/broker"
-	"github.com/google/uuid"
 	"github.com/pivotal-cf/brokerapi"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -53,8 +53,7 @@ func TestProvision(t *testing.T) {
 		Name:          clusterName,
 		BackupEnabled: true,
 		BIConnector: atlas.BIConnectorConfig{
-			Enabled:        true,
-			ReadPreference: "primary",
+			Enabled: false,
 		},
 		Type:                     "REPLICASET",
 		DiskSizeGB:               10,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -118,9 +118,10 @@ func TestProvision(t *testing.T) {
 	cluster, err = client.GetCluster(clusterName)
 	assert.NoError(t, err)
 
-	// Altering these parameters due to the fact that, they can't be configured from upfront
+	// Altering these parameters due to the fact that, they can't be configured from up front
 	cluster.URI = ""
 	expectedCluster.State = "IDLE"
+	expectedCluster.BIConnector.ReadPreference = "secondary"
 
 	// Ensure response is equal to request cluster
 	assert.Equal(t, expectedCluster, cluster)


### PR DESCRIPTION
Changes:
+ biConnector changed to false
+ misspelling fix
+ readPreference removed from params, since biConnector is false and api doesn't allow it in that case. Is set after the cluster has been provisioned.
