### PR TITLE
CLOUDP-47099: Snyk snapshot on Evergreen

### DIFF
--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -35,7 +35,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           snyk auth ${snyk_token}
-          snyk test
+          snyk monitor
   "integration_tests":
     - command: shell.exec
       params:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -28,7 +28,7 @@ functions:
           curl -L -o snyk https://github.com/snyk/snyk/releases/download/v1.216.0/snyk-linux
           chmod +x snyk
           mv snyk /usr/local/bin/
-  "snyk_check":
+  "snyk_snapshot":
     - command: shell.exec
       type: system
       params:
@@ -119,10 +119,10 @@ tasks:
   - name: vet
     commands:
       - func: "go_vet"
-  - name: snyk_check
+  - name: snyk_snapshot
     commands:
       - func: "setup_snyk"
-      - func: "snyk_check"
+      - func: "snyk_snapshot"
   - name: integration_tests
     commands:
       - func: "integration_tests"
@@ -151,7 +151,7 @@ task_groups:
       - func: "fetch_source"
     tasks:
       - vet
-      - snyk_check
+      - snyk_snapshot
   - name: test_task_group
     setup_group:
       - func: "fetch_source"

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -126,16 +126,16 @@ tasks:
       - func: "publish_docker"
 
 task_groups:
-  - name: unit_task_group
+  - name: code_health_task_group
+    setup_group:
+      - func: "fetch_source"
+    tasks:
+      - vet
+  - name: test_task_group
     setup_group:
       - func: "fetch_source"
     tasks:
       - unit_tests
-      - vet
-  - name: integration_task_group
-    setup_group:
-      - func: "fetch_source"
-    tasks:
       - integration_tests
 
 buildvariants:
@@ -143,8 +143,12 @@ buildvariants:
     display_name: test
     run_on: archlinux-test
     tasks:
-      - unit_task_group
-      - integration_task_group
+      - test_task_group
+  - name: code_health
+    display_name: code_health
+    run_on: archlinux-test
+    tasks:
+      - code_health_task_group
   - name: release
     display_name: release
     run_on: archlinux-test

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -35,7 +35,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           export PATH="${workdir}/bin:$PATH"
-          snyk auth ${snyk_token}
+          snyk auth ${snyk-evergreen-upload-atlas-service-broker}
           snyk monitor
   "integration_tests":
     - command: shell.exec

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -20,6 +20,22 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           go vet ./...
+  "setup_snyk":
+    - command: shell.exec
+      type: system
+      params:
+        script: |
+          curl -L -o snyk https://github.com/snyk/snyk/releases/download/v1.216.0/snyk-linux
+          chmod +x snyk
+          mv snyk /usr/local/bin/
+  "snyk_test":
+    - command: shell.exec
+      type: system
+      params:
+        working_dir: src/atlas-service-broker
+        script: |
+          snyk auth ${snyk_token}
+          snyk test
   "integration_tests":
     - command: shell.exec
       params:
@@ -103,6 +119,10 @@ tasks:
   - name: vet
     commands:
       - func: "go_vet"
+  - name: snyk_test
+    commands:
+      - func: "setup_snyk"
+      - func: "snyk_test"
   - name: integration_tests
     commands:
       - func: "integration_tests"
@@ -131,6 +151,7 @@ task_groups:
       - func: "fetch_source"
     tasks:
       - vet
+      - snyk_test
   - name: test_task_group
     setup_group:
       - func: "fetch_source"

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -25,15 +25,16 @@ functions:
       type: system
       params:
         script: |
-          curl -L -o snyk https://github.com/snyk/snyk/releases/download/v1.216.0/snyk-linux
-          chmod +x snyk
-          mv snyk /usr/local/bin/
+          mkdir bin
+          curl -L -o bin/snyk https://github.com/snyk/snyk/releases/download/v1.216.0/snyk-linux
+          chmod +x bin/snyk
   "snyk_snapshot":
     - command: shell.exec
       type: system
       params:
         working_dir: src/atlas-service-broker
         script: |
+          export PATH="${workdir}/bin:$PATH"
           snyk auth ${snyk_token}
           snyk monitor
   "integration_tests":

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -28,7 +28,7 @@ functions:
           curl -L -o snyk https://github.com/snyk/snyk/releases/download/v1.216.0/snyk-linux
           chmod +x snyk
           mv snyk /usr/local/bin/
-  "snyk_test":
+  "snyk_check":
     - command: shell.exec
       type: system
       params:
@@ -119,10 +119,10 @@ tasks:
   - name: vet
     commands:
       - func: "go_vet"
-  - name: snyk_test
+  - name: snyk_check
     commands:
       - func: "setup_snyk"
-      - func: "snyk_test"
+      - func: "snyk_check"
   - name: integration_tests
     commands:
       - func: "integration_tests"
@@ -151,7 +151,7 @@ task_groups:
       - func: "fetch_source"
     tasks:
       - vet
-      - snyk_test
+      - snyk_check
   - name: test_task_group
     setup_group:
       - func: "fetch_source"


### PR DESCRIPTION
We are using Snyk to track dependencies and find vulnerabilities. With this PR we add a new task to Evergreen which will publish a snapshot to Snyk. Snyk will analyze the snapshot and report any vulnerabilities asynchronously. It will also keep track of any new vulnerabilities that pop up. This test should always pass.

I also took the opportunity to refactor our Evergreen file with a new variant `code_health`. Previously `go vet` was run as part of the unit test which didn't make much sense. Now vet and Snyk are run as part of the code_health variant.