### PR TITLE
CLOUDP-47511: Renamed struct fields to match API

### DIFF
--- a/pkg/atlas/atlas.go
+++ b/pkg/atlas/atlas.go
@@ -61,11 +61,6 @@ func NewClient(baseURL string, groupID string, publicKey string, privateKey stri
 	}, nil
 }
 
-// GetDashboardURL prepares the url where the specific cluster can be found in the Dashboard UI
-func (c *HTTPClient) GetDashboardURL(clusterName string) string {
-	return fmt.Sprintf("%s/v2/%s#clusters/detail/%s", c.baseURL, c.groupID, clusterName)
-}
-
 // requestPublic will make a request to an endpoint in the public API.
 // The URL will be constructed by prepending the group to the specified endpoint.
 func (c *HTTPClient) requestPublic(method string, endpoint string, body interface{}, response interface{}) error {

--- a/pkg/atlas/cluster.go
+++ b/pkg/atlas/cluster.go
@@ -28,7 +28,7 @@ type Cluster struct {
 	AutoScaling              AutoScalingConfig `json:"autoScaling,omitempty"`
 	BackupEnabled            bool              `json:"backupEnabled,omitempty"`
 	BIConnector              BIConnectorConfig `json:"biConnector,omitempty"`
-	Type                     string            `json:"clusterType,omitempty"`
+	ClusterType              string            `json:"clusterType,omitempty"`
 	DiskSizeGB               float64           `json:"diskSizeGB,omitempty"`
 	EncryptionAtRestProvider string            `json:"encryptionAtRestProvider,omitempty"`
 	MongoDBMajorVersion      string            `json:"mongoDBMajorVersion,omitempty"`
@@ -38,8 +38,8 @@ type Cluster struct {
 	ProviderSettings         *ProviderSettings `json:"providerSettings"`
 
 	// Read-only attributes
-	State string `json:"stateName,omitempty"`
-	URI   string `json:"srvAddress,omitempty"`
+	StateName  string `json:"stateName,omitempty"`
+	SrvAddress string `json:"srvAddress,omitempty"`
 }
 
 // AutoScalingConfig represents the autoscaling settings for a cluster.
@@ -55,13 +55,13 @@ type BIConnectorConfig struct {
 
 // ProviderSettings represents the provider setting for a cluster.
 type ProviderSettings struct {
-	Name            string `json:"providerName"`
-	Instance        string `json:"instanceSizeName"`
-	Region          string `json:"regionName,omitempty"`
-	BackingProvider string `json:"backingProviderName,omitempty"`
+	ProviderName        string `json:"providerName"`
+	InstanceSizeName    string `json:"instanceSizeName"`
+	RegionName          string `json:"regionName,omitempty"`
+	BackingProviderName string `json:"backingProviderName,omitempty"`
 
 	DiskIOPS         uint   `json:"diskIOPS,omitempty"`
-	DiskType         string `json:"diskTypeName,omitempty"`
+	DiskTypeName     string `json:"diskTypeName,omitempty"`
 	EncryptEBSVolume bool   `json:"encryptEBSVolume,omitempty"`
 	VolumeType       string `json:"volumeType,omitempty"`
 }
@@ -117,4 +117,9 @@ func (c *HTTPClient) GetCluster(name string) (*Cluster, error) {
 	var cluster Cluster
 	err := c.requestPublic(http.MethodGet, path, nil, &cluster)
 	return &cluster, err
+}
+
+// GetDashboardURL prepares the url where the specific cluster can be found in the Dashboard UI
+func (c *HTTPClient) GetDashboardURL(clusterName string) string {
+	return fmt.Sprintf("%s/v2/%s#clusters/detail/%s", c.baseURL, c.groupID, clusterName)
 }

--- a/pkg/atlas/cluster_test.go
+++ b/pkg/atlas/cluster_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestCreateCluster(t *testing.T) {
 	expected := Cluster{
-		Name:  "Cluster",
-		State: ClusterStateIdle,
-		Type:  ClusterTypeReplicaSet,
+		Name:        "Cluster",
+		StateName:   ClusterStateIdle,
+		ClusterType: ClusterTypeReplicaSet,
 	}
 
 	atlas, server := setupTest(t, "/clusters", http.MethodPost, 200, expected)
@@ -25,9 +25,9 @@ func TestCreateCluster(t *testing.T) {
 
 func TestCreateClusterExistingName(t *testing.T) {
 	cluster := Cluster{
-		Name:  "Cluster",
-		State: ClusterStateIdle,
-		Type:  ClusterTypeReplicaSet,
+		Name:        "Cluster",
+		StateName:   ClusterStateIdle,
+		ClusterType: ClusterTypeReplicaSet,
 	}
 
 	atlas, server := setupTest(t, "/clusters", http.MethodPost, 400, errorResponse("DUPLICATE_CLUSTER_NAME"))
@@ -40,9 +40,9 @@ func TestCreateClusterExistingName(t *testing.T) {
 
 func TestUpdateCluster(t *testing.T) {
 	expected := Cluster{
-		Name:  "Cluster",
-		State: ClusterStateIdle,
-		Type:  ClusterTypeReplicaSet,
+		Name:        "Cluster",
+		StateName:   ClusterStateIdle,
+		ClusterType: ClusterTypeReplicaSet,
 	}
 
 	atlas, server := setupTest(t, "/clusters/"+expected.Name, http.MethodPatch, 200, expected)
@@ -56,9 +56,9 @@ func TestUpdateCluster(t *testing.T) {
 
 func TestUpdateNonexistentCluster(t *testing.T) {
 	expected := Cluster{
-		Name:  "Cluster",
-		State: ClusterStateIdle,
-		Type:  ClusterTypeReplicaSet,
+		Name:        "Cluster",
+		StateName:   ClusterStateIdle,
+		ClusterType: ClusterTypeReplicaSet,
 	}
 
 	atlas, server := setupTest(t, "/clusters/"+expected.Name, http.MethodPatch, 400, errorResponse("CLUSTER_NOT_FOUND"))
@@ -71,9 +71,9 @@ func TestUpdateNonexistentCluster(t *testing.T) {
 
 func TestGetCluster(t *testing.T) {
 	expected := &Cluster{
-		Name:  "Cluster",
-		State: ClusterStateIdle,
-		Type:  ClusterTypeReplicaSet,
+		Name:        "Cluster",
+		StateName:   ClusterStateIdle,
+		ClusterType: ClusterTypeReplicaSet,
 	}
 
 	atlas, server := setupTest(t, "/clusters/"+expected.Name, http.MethodGet, 200, expected)

--- a/pkg/atlas/user.go
+++ b/pkg/atlas/user.go
@@ -7,18 +7,18 @@ import (
 
 // User represents a single Atlas database user.
 type User struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Database string `json:"databaseName"`
-	LDAPType string `json:"ldapAuthType,omitempty"`
-	Roles    []Role `json:"roles,omitempty"`
+	Username     string `json:"username"`
+	Password     string `json:"password"`
+	DatabaseName string `json:"databaseName"`
+	LDAPAuthType string `json:"ldapAuthType,omitempty"`
+	Roles        []Role `json:"roles,omitempty"`
 }
 
 // Role represents the role of a database user.
 type Role struct {
-	Name       string `json:"roleName"`
-	Database   string `json:"databaseName,omitempty"`
-	Collection string `json:"collectionName,omitempty"`
+	Name           string `json:"roleName"`
+	DatabaseName   string `json:"databaseName,omitempty"`
+	CollectionName string `json:"collectionName,omitempty"`
 }
 
 // CreateUser will create a new database user with read/write access to all
@@ -26,7 +26,7 @@ type Role struct {
 // Endpoint: POST /databaseUsers
 func (c *HTTPClient) CreateUser(user User) (*User, error) {
 	// Atlas always uses "admin" for the authentication database.
-	user.Database = "admin"
+	user.DatabaseName = "admin"
 
 	var resultingUser User
 	err := c.requestPublic(http.MethodPost, "databaseUsers", user, &resultingUser)

--- a/pkg/broker/binding_operations.go
+++ b/pkg/broker/binding_operations.go
@@ -61,7 +61,7 @@ func (b Broker) Bind(ctx context.Context, instanceID string, bindingID string, d
 		Credentials: ConnectionDetails{
 			Username: bindingID,
 			Password: password,
-			URI:      cluster.URI,
+			URI:      cluster.SrvAddress,
 		},
 	}
 	return
@@ -148,8 +148,8 @@ func userFromParams(bindingID string, password string, rawParams []byte) (*atlas
 	if len(params.User.Roles) == 0 {
 		params.User.Roles = []atlas.Role{
 			atlas.Role{
-				Name:     "readWriteAnyDatabase",
-				Database: "admin",
+				Name:         "readWriteAnyDatabase",
+				DatabaseName: "admin",
 			},
 		}
 	}

--- a/pkg/broker/binding_operations_test.go
+++ b/pkg/broker/binding_operations_test.go
@@ -31,8 +31,8 @@ func TestBind(t *testing.T) {
 
 	expectedRoles := []atlas.Role{
 		atlas.Role{
-			Name:     "readWriteAnyDatabase",
-			Database: "admin",
+			Name:         "readWriteAnyDatabase",
+			DatabaseName: "admin",
 		},
 	}
 	assert.Equal(t, expectedRoles, user.Roles, "Expected default role to have been assigned")
@@ -67,13 +67,13 @@ func TestBindParams(t *testing.T) {
 
 	assert.Equal(t, bindingID, user.Username)
 	assert.NotEmpty(t, user.Password, "Expected password to have been genereated")
-	assert.Equal(t, "NONE", user.LDAPType)
+	assert.Equal(t, "NONE", user.LDAPAuthType)
 
 	expectedRoles := []atlas.Role{
 		atlas.Role{
-			Name:       "role",
-			Database:   "database",
-			Collection: "collection",
+			Name:           "role",
+			DatabaseName:   "database",
+			CollectionName: "collection",
 		},
 	}
 	assert.Equal(t, expectedRoles, user.Roles)

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -20,7 +20,7 @@ func (m MockAtlasClient) CreateCluster(cluster atlas.Cluster) (*atlas.Cluster, e
 		return nil, atlas.ErrClusterAlreadyExists
 	}
 
-	cluster.State = atlas.ClusterStateCreating
+	cluster.StateName = atlas.ClusterStateCreating
 
 	m.Clusters[cluster.Name] = &cluster
 
@@ -62,7 +62,7 @@ func (m MockAtlasClient) SetClusterState(name string, state string) {
 		return
 	}
 
-	cluster.State = state
+	cluster.StateName = state
 }
 
 func (m MockAtlasClient) CreateUser(user atlas.User) (*atlas.User, error) {

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -85,12 +85,12 @@ func (b Broker) Update(ctx context.Context, instanceID string, details brokerapi
 	// size if the provider object is set. If they are missing we use the
 	// existing values.
 	if cluster.ProviderSettings != nil {
-		if cluster.ProviderSettings.Name == "" {
-			cluster.ProviderSettings.Name = existingCluster.ProviderSettings.Name
+		if cluster.ProviderSettings.ProviderName == "" {
+			cluster.ProviderSettings.ProviderName = existingCluster.ProviderSettings.ProviderName
 		}
 
-		if cluster.ProviderSettings.Instance == "" {
-			cluster.ProviderSettings.Instance = existingCluster.ProviderSettings.Instance
+		if cluster.ProviderSettings.InstanceSizeName == "" {
+			cluster.ProviderSettings.InstanceSizeName = existingCluster.ProviderSettings.InstanceSizeName
 		}
 	}
 
@@ -161,7 +161,7 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details br
 
 	switch details.OperationData {
 	case OperationProvision:
-		switch cluster.State {
+		switch cluster.StateName {
 		// Provision has succeeded if the cluster is in state "idle".
 		case atlas.ClusterStateIdle:
 			state = brokerapi.Succeeded
@@ -172,15 +172,15 @@ func (b Broker) LastOperation(ctx context.Context, instanceID string, details br
 		// The Atlas API may return a 404 response if a cluster is deleted or it
 		// will return the cluster with a state of "DELETED". Both of these
 		// scenarios indicate that a cluster has been successfully deleted.
-		if err == atlas.ErrClusterNotFound || cluster.State == atlas.ClusterStateDeleted {
+		if err == atlas.ErrClusterNotFound || cluster.StateName == atlas.ClusterStateDeleted {
 			state = brokerapi.Succeeded
-		} else if cluster.State == atlas.ClusterStateDeleting {
+		} else if cluster.StateName == atlas.ClusterStateDeleting {
 			state = brokerapi.InProgress
 		}
 	case OperationUpdate:
 		// We assume that the cluster transitions to the "UPDATING" state
 		// in a synchronous manner during the update request.
-		switch cluster.State {
+		switch cluster.StateName {
 		case atlas.ClusterStateIdle:
 			state = brokerapi.Succeeded
 		case atlas.ClusterStateUpdating:
@@ -244,8 +244,8 @@ func (b Broker) clusterFromParams(instanceID string, serviceID string, planID st
 		}
 
 		// Configure provider based on service and plan.
-		params.Cluster.ProviderSettings.Name = provider.Name
-		params.Cluster.ProviderSettings.Instance = instanceSize.Name
+		params.Cluster.ProviderSettings.ProviderName = provider.Name
+		params.Cluster.ProviderSettings.InstanceSizeName = instanceSize.Name
 	}
 
 	// Add the instance ID as the name of the cluster.

--- a/pkg/broker/instance_operations_test.go
+++ b/pkg/broker/instance_operations_test.go
@@ -64,8 +64,8 @@ func TestProvision(t *testing.T) {
 	cluster := client.Clusters[instanceID]
 	assert.NotEmptyf(t, cluster, "Expected cluster with name \"%s\" to exist", instanceID)
 	assert.Equal(t, &atlas.ProviderSettings{
-		Name:     "AWS",
-		Instance: "M10",
+		ProviderName:     "AWS",
+		InstanceSizeName: "M10",
 	}, cluster.ProviderSettings)
 }
 
@@ -122,13 +122,13 @@ func TestProvisionParams(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := &atlas.Cluster{
-		State: "CREATING",
+		StateName: "CREATING",
 
 		Name:                     instanceID,
 		AutoScaling:              atlas.AutoScalingConfig{DiskGBEnabled: true},
 		BackupEnabled:            true,
 		BIConnector:              atlas.BIConnectorConfig{Enabled: true, ReadPreference: "primary"},
-		Type:                     "SHARDED",
+		ClusterType:              "SHARDED",
 		DiskSizeGB:               100.0,
 		EncryptionAtRestProvider: "NONE",
 		MongoDBMajorVersion:      "4.0",
@@ -150,11 +150,11 @@ func TestProvisionParams(t *testing.T) {
 			},
 		},
 		ProviderSettings: &atlas.ProviderSettings{
-			Name:             "AWS",
-			Instance:         "M10",
-			Region:           "EU_CENTRAL_1",
+			ProviderName:     "AWS",
+			InstanceSizeName: "M10",
+			RegionName:       "EU_CENTRAL_1",
 			DiskIOPS:         10,
-			DiskType:         "P4",
+			DiskTypeName:     "P4",
 			EncryptEBSVolume: true,
 			VolumeType:       "STANDARD",
 		},
@@ -207,8 +207,8 @@ func TestUpdate(t *testing.T) {
 
 	// Ensure the instance size was updated and the provider
 	// was not.
-	assert.Equal(t, "M20", cluster.ProviderSettings.Instance)
-	assert.Equal(t, "AWS", cluster.ProviderSettings.Name)
+	assert.Equal(t, "M20", cluster.ProviderSettings.InstanceSizeName)
+	assert.Equal(t, "AWS", cluster.ProviderSettings.ProviderName)
 }
 
 func TestUpdateWithoutPlan(t *testing.T) {
@@ -230,9 +230,9 @@ func TestUpdateWithoutPlan(t *testing.T) {
 	}, true)
 
 	cluster := client.Clusters[instanceID]
-	assert.Equal(t, "M10", cluster.ProviderSettings.Instance)
-	assert.Equal(t, "AWS", cluster.ProviderSettings.Name)
-	assert.Equal(t, "EU_WEST_1", cluster.ProviderSettings.Region)
+	assert.Equal(t, "M10", cluster.ProviderSettings.InstanceSizeName)
+	assert.Equal(t, "AWS", cluster.ProviderSettings.ProviderName)
+	assert.Equal(t, "EU_WEST_1", cluster.ProviderSettings.RegionName)
 
 	// Try updating the instance without specifying a plan ID. The expected
 	// behaviour is for the existing plan (instance size) to remain the same.
@@ -260,9 +260,9 @@ func TestUpdateWithoutPlan(t *testing.T) {
 
 	// Ensure the service and plan were not changed, whilst the region should
 	// have changed.
-	assert.Equal(t, "M10", updatedCluster.ProviderSettings.Instance)
-	assert.Equal(t, "AWS", updatedCluster.ProviderSettings.Name)
-	assert.Equal(t, "EU_CENTRAL_1", updatedCluster.ProviderSettings.Region)
+	assert.Equal(t, "M10", updatedCluster.ProviderSettings.InstanceSizeName)
+	assert.Equal(t, "AWS", updatedCluster.ProviderSettings.ProviderName)
+	assert.Equal(t, "EU_CENTRAL_1", updatedCluster.ProviderSettings.RegionName)
 }
 
 func TestUpdateNonexistent(t *testing.T) {


### PR DESCRIPTION
With this PR we update the names of all struct fields in the `atlas`  package to match their counterparts in the Atlas API.