### PR TITLE
CLOUDP-47373: Test PR from outside 10gen team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Testing pull request coming from outside the 10gen team. Every change should be reviewed before scheduling the Evergreen patch.
+
 # MongoDB Atlas Service Broker
 
 Use the Atlas Service Broker to connect to [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) from any platform which supports the [Open Service Broker API](https://www.openservicebrokerapi.org/), such as [Kubernetes](https://kubernetes.io/) and [Pivotal Cloud Foundry](https://pivotal.io/open-service-broker).


### PR DESCRIPTION
Evergreen should not schedule patches coming from users outside the 10gen team. Instead the patch should be created and require manual scheduling by a team member.