### PR TITLE
Binding missed checks

### DIFF
--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -82,7 +82,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN={github_token}
+          export GITHUB_TOKEN=${github_token}
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -99,7 +99,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          docker build . -t quay.io/vwmongodb/mongodb-image-release:${version}
+          docker build . -t ${docker_repo}/${docker_name}:${version}
   "publish_docker":
     - command: shell.exec
       params:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -56,11 +56,7 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           # Get version from tag on head and throw error if none exists
-<<<<<<< Updated upstream
           # Remove the character v at the beginning of the string if any, and keep the rest
-=======
-          # COMMENT SED
->>>>>>> Stashed changes
           export VERSION=$(git tag -l --points-at HEAD | sed 's/^v\(.*\)/\1/')
           [[ -z "$VERSION" ]] && { echo "No version tag on HEAD" ; exit 1; }
 
@@ -86,7 +82,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN=c5533b9684a7d432d27a6a66d7fa81c09ab834c5
+          export GITHUB_TOKEN={github_token}
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -109,21 +105,12 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-<<<<<<< Updated upstream
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
 
           docker push ${docker_repo}/${docker_name}:${version}
           if [[ ${version} =~ [0-9]+.[0-9]+.[0-9]+$ ]]; then
             docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest
             docker push ${docker_repo}/${docker_name}:latest
-=======
-          docker login --username "vwmongodb" --password "IamAsecretPass;" quay.io
-
-          docker push quay.io/vwmongodb/mongodb-image-release:${version}
-          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
-            docker image tag quay.io/vwmongodb/mongodb-image-release:${version} quay.io/vwmongodb/mongodb-image-release:latest
-            docker push quay.io/vwmongodb/mongodb-image-release:latest
->>>>>>> Stashed changes
           fi
 
 tasks:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -56,7 +56,11 @@ functions:
         working_dir: src/atlas-service-broker
         script: |
           # Get version from tag on head and throw error if none exists
+<<<<<<< Updated upstream
           # Remove the character v at the beginning of the string if any, and keep the rest
+=======
+          # COMMENT SED
+>>>>>>> Stashed changes
           export VERSION=$(git tag -l --points-at HEAD | sed 's/^v\(.*\)/\1/')
           [[ -z "$VERSION" ]] && { echo "No version tag on HEAD" ; exit 1; }
 
@@ -105,12 +109,21 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
+<<<<<<< Updated upstream
           docker login --username ${docker_username} --password ${docker_password} ${docker_repo}
 
           docker push ${docker_repo}/${docker_name}:${version}
           if [[ ${version} =~ [0-9]+.[0-9]+.[0-9]+$ ]]; then
             docker image tag ${docker_repo}/${docker_name}:${version} ${docker_repo}/${docker_name}:latest
             docker push ${docker_repo}/${docker_name}:latest
+=======
+          docker login --username "vwmongodb" --password "IamAsecretPass;" quay.io
+
+          docker push quay.io/vwmongodb/mongodb-image-release:${version}
+          if [[ ${version} =~ [0-9]+.[0-9]+$ ]]; then
+            docker image tag quay.io/vwmongodb/mongodb-image-release:${version} quay.io/vwmongodb/mongodb-image-release:latest
+            docker push quay.io/vwmongodb/mongodb-image-release:latest
+>>>>>>> Stashed changes
           fi
 
 tasks:

--- a/.evergreen.yaml
+++ b/.evergreen.yaml
@@ -82,7 +82,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          export GITHUB_TOKEN=${github_token}
+          export GITHUB_TOKEN=c5533b9684a7d432d27a6a66d7fa81c09ab834c5
 
           # Get all artifacts and turn them into a list with --attach flags
           export ARTIFACTS_ATTACH=$(ls artifacts | xargs -I {} echo "--attach artifacts/{} ")
@@ -99,7 +99,7 @@ functions:
       params:
         working_dir: src/atlas-service-broker
         script: |
-          docker build . -t ${docker_repo}/${docker_name}:${version}
+          docker build . -t quay.io/vwmongodb/mongodb-image-release:${version}
   "publish_docker":
     - command: shell.exec
       params:

--- a/pkg/broker/binding_operations.go
+++ b/pkg/broker/binding_operations.go
@@ -53,7 +53,7 @@ func (b Broker) Bind(ctx context.Context, instanceID string, bindingID string, d
 	}
 
 	// Construct a cluster definition from the instance ID, service, plan, and params.
-	user, err := b.userFromParams(bindingID, password, details.RawParameters)
+	user, err := userFromParams(bindingID, password, details.RawParameters)
 	if err != nil {
 		b.logger.Errorw("Couldn't create user from the passed parameters", "error", err, "instance_id", instanceID, "binding_id", bindingID, "details", details)
 		return
@@ -135,7 +135,7 @@ func generatePassword() (string, error) {
 	return base64.URLEncoding.EncodeToString(b), nil
 }
 
-func (b Broker) userFromParams(bindingID string, password string, rawParams []byte) (*atlas.User, error) {
+func userFromParams(bindingID string, password string, rawParams []byte) (*atlas.User, error) {
 	// Set up a params object which will be used for deserialiation.
 	params := struct {
 		User *atlas.User `json:"user"`

--- a/pkg/broker/binding_operations.go
+++ b/pkg/broker/binding_operations.go
@@ -139,7 +139,8 @@ func (b Broker) userFromParams(bindingID string, password string, serviceID stri
 		}
 	}
 
-	// The service_id and plan_id are required to not be empty and have an invalid format.
+	// The service_id and plan_id are required to be valid per the specification, despite
+	// not being used for bindings. We look them up to ensure they can be found in the catalog.
 	provider, err := b.findProviderByServiceID(serviceID)
 	if err != nil {
 		return nil, err

--- a/pkg/broker/binding_operations_test.go
+++ b/pkg/broker/binding_operations_test.go
@@ -114,7 +114,10 @@ func TestBindMissingInstance(t *testing.T) {
 
 	instanceID := "instance"
 	bindingID := "binding"
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{}, true)
+	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
 	assert.EqualError(t, err, apiresponses.ErrInstanceDoesNotExist.Error())
 }
@@ -163,7 +166,10 @@ func TestUnbindMissingInstance(t *testing.T) {
 
 	instanceID := "instance"
 	bindingID := "binding"
-	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{}, true)
+	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
 	assert.EqualError(t, err, apiresponses.ErrInstanceDoesNotExist.Error())
 }

--- a/pkg/broker/binding_operations_test.go
+++ b/pkg/broker/binding_operations_test.go
@@ -20,7 +20,11 @@ func TestBind(t *testing.T) {
 	}, true)
 
 	bindingID := "binding"
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{}, true)
+
+	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
 	assert.NoError(t, err)
 
@@ -58,7 +62,11 @@ func TestBindParams(t *testing.T) {
 		}}`
 
 	bindingID := "binding"
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{RawParameters: []byte(params)}, true)
+	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:        testPlanID,
+		ServiceID:     testServiceID,
+		RawParameters: []byte(params),
+	}, true)
 
 	assert.NoError(t, err)
 
@@ -89,8 +97,14 @@ func TestBindAlreadyExisting(t *testing.T) {
 	}, true)
 
 	bindingID := "binding"
-	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{}, true)
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{}, true)
+	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
+	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
 	assert.EqualError(t, err, apiresponses.ErrBindingAlreadyExists.Error())
 }
@@ -115,9 +129,15 @@ func TestUnbind(t *testing.T) {
 	}, true)
 
 	bindingID := "binding"
-	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{}, true)
+	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
-	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{}, true)
+	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{
+		PlanID:    testPlanID,
+		ServiceID: testServiceID,
+	}, true)
 
 	assert.NoError(t, err)
 	assert.Empty(t, client.Users[bindingID], "Expected to be removed")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -219,6 +219,8 @@ func TestBind(t *testing.T) {
 		}}`
 
 	spec, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+		ServiceID:     "aosb-cluster-service-aws",
+		PlanID:        "aosb-cluster-plan-aws-m10",
 		RawParameters: []byte(params),
 	}, true)
 	defer teardownBinding(bindingID)


### PR DESCRIPTION
Changes:
Binding was missing checks for service_id and plan_id. This means if somebody was to sent xxxx-xxxx-xxx-xxx for the service_id, it would bind it anyway or if the plan_id and the service_id were both blank or one of them, it would return a 500 error code instead of the 400 error code.

This error was identified by the OSB Checker Linter. 