### PR TITLE
CLOUDP:48406: Accept API keys through HTTP basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,14 @@ For instructions on how to install and use the MongoDB Atlas Service Broker plea
 
 ## Configuration
 
-Configuration is handled with environment variables.
-
-### Atlas API
+Configuration is handled with environment variables. Logs are written to
+`stderr` and each line is in a structured JSON format.
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| ATLAS_GROUP_ID | **Required** | Group in which to provision new clusters |
-| ATLAS_PUBLIC_KEY | **Required** | Public part of the Atlas API key |
-| ATLAS_PRIVATE_KEY | **Required** | Private part of the Atlas API key |
 | ATLAS_BASE_URL | `https://cloud.mongodb.com` | Base URL used for Atlas API connections |
-
-### Broker API Server
-
-| Variable | Default | Description |
-| -------- | ------- | ----------- |
-| BROKER_USERNAME | **Required** | Username for basic auth against broker |
-| BROKER_PASSWORD | **Required** | Password for basic auth against broker |
 | BROKER_HOST | `127.0.0.1` | Address which the broker server listens on |
 | BROKER_PORT | `4000` | Port which the broker server listens on |
-
-### Logs
-
-Logs are written to `stderr` and each line is in a structured JSON format.
-
-| Variable | Default | Description |
-| -------- | ------- | ----------- |
 | BROKER_LOG_LEVEL | `INFO` | Accepted values: `DEBUG`, `INFO`, `WARN`, `ERROR` |
 
 ## License

--- a/dev/README.md
+++ b/dev/README.md
@@ -36,23 +36,21 @@ Follow these steps to test the broker in a Kubernetes cluster. For local testing
    be found in the [Kubernetes docs](https://kubernetes.io/docs/tasks/service-catalog/install-service-catalog-using-helm/).
 3. Build the Dockerfile and make the resulting image available in your cluster. If you are using
    Minikube `dev/scripts/minikube-build.sh` can be used to build the image using Minikube's Docker
-   daemon. Update the deployment resource in `samples/kubernetes/deployment.yaml` to have `imagePullPolicy: Never`.
+   daemon. Update the deployment resource in `samples/kubernetes/deployment.yaml` to have
+   `imagePullPolicy: Never` and update the `ATLAS_BASE_URL` to whichever environment you're testing against.
 4. Create a new namespace `atlas` by running `kubectl create namespace atlas`.
-5. Create a secret called `atlas-api` containing the following keys:
-   - `base-url`for the Atlas API
-   - `group-id` for the project under which clusters should be deployed
-   - `public-key`for the API key
-   - `private-key`for the API key
+5. Create a secret called `atlas-service-broker-auth` containing the following keys:
+   - `username` should be the Atlas group ID and public key combined as `<PUBLIC_KEY>@<GROUP_ID>`.
+   - `password` should be the Atlas private key.
 6. Deploy the service broker by running `kubectl apply -f samples/kubernetes/deployment.yaml -n atlas`. This will create
-   a new deployment and a service of the image from step 2. It will also create a new secret containing the
-   basic auth credentials for the service catalog which are needed for the next step.
+   a new deployment and a service of the image from step 2.
 7. Register the service broker with the service catalog by running `kubectl apply -f samples/kubernetes/service-broker.yaml -n atlas`.
 8. Make sure the broker is ready by running `svcat get brokers`.
-9. A new instance can be provisioned by running `kubectl create -f scripts/kubernetes/instance.yaml -n atlas`.
+9. A new instance can be provisioned by running `kubectl create -f samples/kubernetes/instance.yaml -n atlas`.
    The instance will be given the name `atlas-cluster-instance` and its status can be checked using `svcat get instances -n atlas`.
 10. Once the instance is up and running, a binding can be created to gain access. A binding named
    `atlas-cluster-binding` can be created by running `kubectl create -f
-   script/kubernetes/binding.yaml -n atlas`. The binding credentials will automatically be stored in a secret
+   samples/kubernetes/binding.yaml -n atlas`. The binding credentials will automatically be stored in a secret
    of the same name.
 11. After use, all bindings can be removed by running `svcat unbind atlas-cluser-instance -n atlas` and the
    cluster can be deprovisioned using `svcat deprovision atlas-cluster-instance -n atlas`.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.1
-	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/gorilla/mux v1.7.3
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/kubernetes-incubator/service-catalog v0.2.1
 	github.com/kubernetes-sigs/service-catalog v0.2.1

--- a/pkg/atlas/atlas.go
+++ b/pkg/atlas/atlas.go
@@ -129,7 +129,7 @@ func (c *HTTPClient) request(method string, url string, body interface{}, respon
 		return nil
 	}
 
-	// Invalid credentials will cause a 401 Unauthorized response
+	// Invalid credentials will cause a 401 Unauthorized response.
 	if resp.StatusCode == http.StatusUnauthorized {
 		return ErrUnauthorized
 	}

--- a/pkg/atlas/atlas.go
+++ b/pkg/atlas/atlas.go
@@ -51,14 +51,14 @@ const (
 )
 
 // NewClient will create a new HTTPClient with the specified connection details.
-func NewClient(baseURL string, groupID string, publicKey string, privateKey string) (*HTTPClient, error) {
+func NewClient(baseURL string, groupID string, publicKey string, privateKey string) *HTTPClient {
 	return &HTTPClient{
 		baseURL:    baseURL,
 		groupID:    groupID,
 		publicKey:  publicKey,
 		privateKey: privateKey,
 		HTTP:       &http.Client{},
-	}, nil
+	}
 }
 
 // requestPublic will make a request to an endpoint in the public API.

--- a/pkg/atlas/atlas.go
+++ b/pkg/atlas/atlas.go
@@ -38,6 +38,8 @@ type HTTPClient struct {
 
 // Different errors the api may return.
 var (
+	ErrUnauthorized = errors.New("Invalid API key")
+
 	ErrClusterNotFound      = errors.New("Cluster not found")
 	ErrClusterAlreadyExists = errors.New("Cluster already exists")
 
@@ -125,6 +127,11 @@ func (c *HTTPClient) request(method string, url string, body interface{}, respon
 		}
 
 		return nil
+	}
+
+	// Invalid credentials will cause a 401 Unauthorized response
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrUnauthorized
 	}
 
 	// Decode error if request was unsuccessful.

--- a/pkg/atlas/atlas.go
+++ b/pkg/atlas/atlas.go
@@ -28,10 +28,10 @@ type Client interface {
 // HTTPClient is the main implementation of the Client interface which
 // communicates with the Atlas API.
 type HTTPClient struct {
-	baseURL    string
-	groupID    string
-	publicKey  string
-	privateKey string
+	BaseURL    string
+	GroupID    string
+	PublicKey  string
+	PrivateKey string
 
 	HTTP *http.Client
 }
@@ -55,10 +55,10 @@ const (
 // NewClient will create a new HTTPClient with the specified connection details.
 func NewClient(baseURL string, groupID string, publicKey string, privateKey string) *HTTPClient {
 	return &HTTPClient{
-		baseURL:    baseURL,
-		groupID:    groupID,
-		publicKey:  publicKey,
-		privateKey: privateKey,
+		BaseURL:    baseURL,
+		GroupID:    groupID,
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
 		HTTP:       &http.Client{},
 	}
 }
@@ -66,13 +66,13 @@ func NewClient(baseURL string, groupID string, publicKey string, privateKey stri
 // requestPublic will make a request to an endpoint in the public API.
 // The URL will be constructed by prepending the group to the specified endpoint.
 func (c *HTTPClient) requestPublic(method string, endpoint string, body interface{}, response interface{}) error {
-	url := fmt.Sprintf("%s%s/groups/%s/%s", c.baseURL, publicAPIPath, c.groupID, endpoint)
+	url := fmt.Sprintf("%s%s/groups/%s/%s", c.BaseURL, publicAPIPath, c.GroupID, endpoint)
 	return c.request(method, url, body, response)
 }
 
 // requestPrivate will make a request to an endpoint in the private API.
 func (c *HTTPClient) requestPrivate(method string, endpoint string, body interface{}, response interface{}) error {
-	url := fmt.Sprintf("%s%s/%s", c.baseURL, privateAPIPath, endpoint)
+	url := fmt.Sprintf("%s%s/%s", c.BaseURL, privateAPIPath, endpoint)
 	return c.request(method, url, body, response)
 }
 
@@ -171,8 +171,8 @@ func (c *HTTPClient) digestAuth(method string, endpoint string) (string, error) 
 	parts["uri"] = endpointURL.RequestURI()
 
 	// User public and private key as username and password
-	parts["username"] = c.publicKey
-	parts["password"] = c.privateKey
+	parts["username"] = c.PublicKey
+	parts["password"] = c.PrivateKey
 
 	return getDigestAuthrization(parts), nil
 }

--- a/pkg/atlas/atlas_test.go
+++ b/pkg/atlas/atlas_test.go
@@ -42,10 +42,8 @@ func setupTest(t *testing.T, expectedPath string, method string, status int, res
 		}
 	}))
 
-	atlas, err := NewClient(s.URL, groupID, publicKey, privateKey)
+	atlas := NewClient(s.URL, groupID, publicKey, privateKey)
 	atlas.HTTP = s.Client()
-
-	assert.NoError(t, err)
 
 	return atlas, s
 }

--- a/pkg/atlas/cluster.go
+++ b/pkg/atlas/cluster.go
@@ -121,5 +121,5 @@ func (c *HTTPClient) GetCluster(name string) (*Cluster, error) {
 
 // GetDashboardURL prepares the url where the specific cluster can be found in the Dashboard UI
 func (c *HTTPClient) GetDashboardURL(clusterName string) string {
-	return fmt.Sprintf("%s/v2/%s#clusters/detail/%s", c.baseURL, c.groupID, clusterName)
+	return fmt.Sprintf("%s/v2/%s#clusters/detail/%s", c.BaseURL, c.GroupID, clusterName)
 }

--- a/pkg/broker/binding_operations_test.go
+++ b/pkg/broker/binding_operations_test.go
@@ -1,7 +1,6 @@
 package broker
 
 import (
-	"context"
 	"testing"
 
 	"github.com/mongodb/mongodb-atlas-service-broker/pkg/atlas"
@@ -11,17 +10,17 @@ import (
 )
 
 func TestBind(t *testing.T) {
-	broker, client := setupTest()
+	broker, client, ctx := setupTest()
 
 	instanceID := "instance"
-	broker.Provision(context.Background(), instanceID, brokerapi.ProvisionDetails{
+	broker.Provision(ctx, instanceID, brokerapi.ProvisionDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
 
 	bindingID := "binding"
 
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	_, err := broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
@@ -43,10 +42,10 @@ func TestBind(t *testing.T) {
 }
 
 func TestBindParams(t *testing.T) {
-	broker, client := setupTest()
+	broker, client, ctx := setupTest()
 
 	instanceID := "instance"
-	broker.Provision(context.Background(), instanceID, brokerapi.ProvisionDetails{
+	broker.Provision(ctx, instanceID, brokerapi.ProvisionDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
@@ -62,7 +61,7 @@ func TestBindParams(t *testing.T) {
 		}}`
 
 	bindingID := "binding"
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	_, err := broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:        testPlanID,
 		ServiceID:     testServiceID,
 		RawParameters: []byte(params),
@@ -88,20 +87,20 @@ func TestBindParams(t *testing.T) {
 }
 
 func TestBindAlreadyExisting(t *testing.T) {
-	broker, _ := setupTest()
+	broker, _, ctx := setupTest()
 
 	instanceID := "instance"
-	broker.Provision(context.Background(), instanceID, brokerapi.ProvisionDetails{
+	broker.Provision(ctx, instanceID, brokerapi.ProvisionDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
 
 	bindingID := "binding"
-	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	_, err := broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
@@ -110,11 +109,11 @@ func TestBindAlreadyExisting(t *testing.T) {
 }
 
 func TestBindMissingInstance(t *testing.T) {
-	broker, _ := setupTest()
+	broker, _, ctx := setupTest()
 
 	instanceID := "instance"
 	bindingID := "binding"
-	_, err := broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	_, err := broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
@@ -123,21 +122,21 @@ func TestBindMissingInstance(t *testing.T) {
 }
 
 func TestUnbind(t *testing.T) {
-	broker, client := setupTest()
+	broker, client, ctx := setupTest()
 
 	instanceID := "instance"
-	broker.Provision(context.Background(), instanceID, brokerapi.ProvisionDetails{
+	broker.Provision(ctx, instanceID, brokerapi.ProvisionDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
 
 	bindingID := "binding"
-	broker.Bind(context.Background(), instanceID, bindingID, brokerapi.BindDetails{
+	broker.Bind(ctx, instanceID, bindingID, brokerapi.BindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
 
-	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{
+	_, err := broker.Unbind(ctx, instanceID, bindingID, brokerapi.UnbindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
@@ -147,26 +146,26 @@ func TestUnbind(t *testing.T) {
 }
 
 func TestUnbindMissing(t *testing.T) {
-	broker, _ := setupTest()
+	broker, _, ctx := setupTest()
 
 	instanceID := "instance"
-	broker.Provision(context.Background(), instanceID, brokerapi.ProvisionDetails{
+	broker.Provision(ctx, instanceID, brokerapi.ProvisionDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)
 
 	bindingID := "binding"
-	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{}, true)
+	_, err := broker.Unbind(ctx, instanceID, bindingID, brokerapi.UnbindDetails{}, true)
 
 	assert.EqualError(t, err, apiresponses.ErrBindingDoesNotExist.Error())
 }
 
 func TestUnbindMissingInstance(t *testing.T) {
-	broker, _ := setupTest()
+	broker, _, ctx := setupTest()
 
 	instanceID := "instance"
 	bindingID := "binding"
-	_, err := broker.Unbind(context.Background(), instanceID, bindingID, brokerapi.UnbindDetails{
+	_, err := broker.Unbind(ctx, instanceID, bindingID, brokerapi.UnbindDetails{
 		PlanID:    testPlanID,
 		ServiceID: testServiceID,
 	}, true)

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -30,6 +30,10 @@ func NewBroker(logger *zap.SugaredLogger) *Broker {
 	}
 }
 
+type ContextKey string
+
+var ContextKeyAtlasClient = ContextKey("atlas-client")
+
 func AuthMiddleware(baseURL string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -48,14 +52,14 @@ func AuthMiddleware(baseURL string) mux.MiddlewareFunc {
 
 			client := atlas.NewClient(baseURL, groupID, publicKey, password)
 
-			ctx := context.WithValue(r.Context(), "atlas-client", client)
+			ctx := context.WithValue(r.Context(), ContextKeyAtlasClient, client)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
 func atlasClientFromContext(ctx context.Context) (atlas.Client, error) {
-	client, ok := ctx.Value("atlas-client").(atlas.Client)
+	client, ok := ctx.Value(ContextKeyAtlasClient).(atlas.Client)
 	if !ok {
 		return nil, errors.New("no Atlas client in context")
 	}

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -50,8 +50,6 @@ func AuthMiddleware(baseURL string) mux.MiddlewareFunc {
 			// The username contains both the group ID and public key
 			// formatted as "<PUBLIC_KEY>@<GROUP_ID>".
 			splitUsername := strings.Split(username, "@")
-			groupID := splitUsername[1]
-			publicKey := splitUsername[0]
 
 			// If the credentials are invalid we respond with 401 Unauthorized.
 			// The username needs have the correct format and the password must
@@ -65,7 +63,7 @@ func AuthMiddleware(baseURL string) mux.MiddlewareFunc {
 
 			// Create a new client with the extracted API credentials and
 			// attach it to the request context.
-			client := atlas.NewClient(baseURL, groupID, publicKey, password)
+			client := atlas.NewClient(baseURL, splitUsername[1], splitUsername[0], password)
 			ctx := context.WithValue(r.Context(), ContextKeyAtlasClient, client)
 
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/pkg/broker/broker.go
+++ b/pkg/broker/broker.go
@@ -74,6 +74,8 @@ func atlasToAPIError(err error) error {
 		return apiresponses.ErrBindingAlreadyExists
 	case atlas.ErrUserNotFound:
 		return apiresponses.ErrBindingDoesNotExist
+	case atlas.ErrUnauthorized:
+		return apiresponses.NewFailureResponse(err, http.StatusUnauthorized, "")
 	}
 
 	// Fall back on returning the error again if no others match.

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -1,6 +1,8 @@
 package broker
 
 import (
+	"context"
+
 	"github.com/mongodb/mongodb-atlas-service-broker/pkg/atlas"
 	"go.uber.org/zap"
 )
@@ -111,11 +113,13 @@ func (m MockAtlasClient) GetDashboardURL(clusterName string) string {
 	return "http://dashboard"
 }
 
-func setupTest() (*Broker, MockAtlasClient) {
+func setupTest() (*Broker, MockAtlasClient, context.Context) {
 	client := MockAtlasClient{
 		Clusters: make(map[string]*atlas.Cluster),
 		Users:    make(map[string]*atlas.User),
 	}
-	broker := NewBroker(client, zap.NewNop().Sugar())
-	return broker, client
+	ctx := context.WithValue(context.Background(), ContextKeyAtlasClient, client)
+
+	broker := NewBroker(zap.NewNop().Sugar())
+	return broker, client, ctx
 }

--- a/pkg/broker/catalog.go
+++ b/pkg/broker/catalog.go
@@ -26,8 +26,13 @@ func (b Broker) Services(ctx context.Context) ([]brokerapi.Service, error) {
 
 	services := make([]brokerapi.Service, len(providerNames))
 
+	client, err := atlasClientFromContext(ctx)
+	if err != nil {
+		return services, err
+	}
+
 	for i, providerName := range providerNames {
-		provider, err := b.atlas.GetProvider(providerName)
+		provider, err := client.GetProvider(providerName)
 		if err != nil {
 			return services, err
 		}
@@ -52,9 +57,9 @@ func (b Broker) Services(ctx context.Context) ([]brokerapi.Service, error) {
 	return services, nil
 }
 
-func (b Broker) findProviderByServiceID(serviceID string) (*atlas.Provider, error) {
+func findProviderByServiceID(client atlas.Client, serviceID string) (*atlas.Provider, error) {
 	for _, providerName := range providerNames {
-		provider, err := b.atlas.GetProvider(providerName)
+		provider, err := client.GetProvider(providerName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/broker/catalog_test.go
+++ b/pkg/broker/catalog_test.go
@@ -1,16 +1,15 @@
 package broker
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCatalog(t *testing.T) {
-	broker, _ := setupTest()
+	broker, _, ctx := setupTest()
 
-	services, err := broker.Services(context.Background())
+	services, err := broker.Services(ctx)
 
 	assert.NoError(t, err)
 	assert.NotZero(t, len(services), "Expected a non-zero amount of services")

--- a/pkg/broker/instance_operations.go
+++ b/pkg/broker/instance_operations.go
@@ -36,7 +36,7 @@ func (b Broker) Provision(ctx context.Context, instanceID string, details broker
 	}
 
 	// Construct a cluster definition from the instance ID, service, plan, and params.
-	cluster, err := b.clusterFromParams(client, instanceID, details.ServiceID, details.PlanID, details.RawParameters)
+	cluster, err := clusterFromParams(client, instanceID, details.ServiceID, details.PlanID, details.RawParameters)
 	if err != nil {
 		b.logger.Errorw("Couldn't create cluster from the passed parameters", "error", err, "instance_id", instanceID, "details", details)
 		return
@@ -85,7 +85,7 @@ func (b Broker) Update(ctx context.Context, instanceID string, details brokerapi
 	}
 
 	// Construct a cluster from the instance ID, service, plan, and params.
-	cluster, err := b.clusterFromParams(client, instanceID, details.ServiceID, details.PlanID, details.RawParameters)
+	cluster, err := clusterFromParams(client, instanceID, details.ServiceID, details.PlanID, details.RawParameters)
 	if err != nil {
 		return
 	}
@@ -230,7 +230,7 @@ func NormalizeClusterName(name string) string {
 // clusterFromParams will construct a cluster object from an instance ID,
 // service, plan, and raw parameters. This way users can pass all the
 // configuration available for clusters in the Atlas API as "cluster" in the params.
-func (b Broker) clusterFromParams(client atlas.Client, instanceID string, serviceID string, planID string, rawParams []byte) (*atlas.Cluster, error) {
+func clusterFromParams(client atlas.Client, instanceID string, serviceID string, planID string, rawParams []byte) (*atlas.Cluster, error) {
 	// Set up a params object which will be used for deserialiation.
 	params := struct {
 		Cluster *atlas.Cluster `json:"cluster"`

--- a/samples/kubernetes/deployment.yaml
+++ b/samples/kubernetes/deployment.yaml
@@ -1,15 +1,4 @@
 ---
-# Secret used to set up HTTP basic auth between the service broker and the service catalog.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: atlas-service-broker-auth
-type: Opaque
-stringData:
-  username: my-username
-  password: my-password
-
----
 # Deployment to run the service broker.
 apiVersion: apps/v1
 kind: Deployment
@@ -30,41 +19,14 @@ spec:
       containers:
         - name: atlas-service-broker
           image: quay.io/mongodb/mongodb-atlas-service-broker:latest
+          imagePullPolicy: Never
           ports:
             - containerPort: 4000
           env:
             - name: BROKER_HOST
               value: "0.0.0.0"
-            - name: BROKER_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-service-broker-auth
-                  key: username
-            - name: BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-service-broker-auth
-                  key: password
             - name: ATLAS_BASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-api
-                  key: base-url
-            - name: ATLAS_GROUP_ID
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-api
-                  key: group-id
-            - name: ATLAS_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-api
-                  key: public-key
-            - name: ATLAS_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: atlas-api
-                  key: private-key
+              value: https://cloud-qa.mongodb.com
 
 ---
 # Service to expose the service broker inside the cluster.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,4 +1,4 @@
-package test
+package integration
 
 import (
 	"context"

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,4 +1,4 @@
-package util 
+package util
 
 import (
 	"fmt"
@@ -28,6 +28,8 @@ func Poll(timeoutMinutes int, f func() (bool, error)) error {
 	return fmt.Errorf("timeout while polling (waited %d minutes)", timeoutMinutes)
 }
 
+// GetEnvOrPanic will get an environment variable, panicking if it does not
+// exist.
 func GetEnvOrPanic(name string) string {
 	value, exists := os.LookupEnv(name)
 	if !exists {


### PR DESCRIPTION
Currently we require environment variables for both the Atlas API credentials and the basic auth between platform and broker. A much nicer solution would be if the Atlas credentials could be passed over basic auth. This way we cut down on the configuration necessary for deploying and also make it much easier to run a hosted service broker in the future.

The basic auth credentials are expected to be formatted like:
Username: <PUBLIC_KEY>@<GROUP_ID>
Password: <PRIVATE_KEY>

The `brokerapi` library doesn't have any built-in support for dynamic authentication. It does support using a custom router and middleware though. With this PR we add an authentication middleware which will parse the basic auth and create an Atlas API client. This client will be saved to the request context which the broker can access.