### PR TITLE
CLOUDP-48516: Add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Configuration is handled with environment variables. Logs are written to
 | BROKER_HOST | `127.0.0.1` | Address which the broker server listens on |
 | BROKER_PORT | `4000` | Port which the broker server listens on |
 | BROKER_LOG_LEVEL | `INFO` | Accepted values: `DEBUG`, `INFO`, `WARN`, `ERROR` |
+| BROKER_TLS_CERT_FILE | | Path to a certificate file to use for TLS. Leave empty to disable TLS. |
+| BROKER_TLS_KEY_FILE | | Path to private key file to use for TLS. Leave empty to disable TLS. |
 
 ## License
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -26,6 +26,19 @@ The release process consists of publishing a new Github release with attached bi
 
 Please include their license in the notices/ directory.
 
+## Setting up TLS in Kubernetes
+
+To enable TLS, perform these steps before continuing with "Testing in Kubernetes".
+
+1. Generate a self-signed certificate and private key by running `openssl req -newkey rsa:2048 -nodes -keyout key-x509 -days 365 -out cert`.
+   When prompted for "Common Name", enter `atlas-service-broker.atlas`. All other fields can be left empty.
+2. Create a new secret containing the key and cert by running `kubectl create secret generic aosb-tls --from-file=./key --from-file=./cert -n atlas`.
+3. Update `samples/kubernetes/deployment.yaml` to mount the secret inside your pod in accordance with this guide: https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod.
+   Also add the `BROKER_TLS_KEY_FILE` and `BROKER_TLS_CERT_FILE` environment variables to point to the mounted secret. If mounted to `/etc/tls_secret`
+   the environment variables would be `/etc/tls_secret/key` and `/etc/tls_secret/cert`. Also change the service port from `80` to `443`.
+4. Update `samples/kubernetes/service-broker.yaml` and add a `caBundle` field containing the base64 encoded contents of `cert`.
+   Run `base64 < cert` to get the base64 string. Also update the `url` field to use `https`.
+
 ## Testing in Kubernetes
 
 Follow these steps to test the broker in a Kubernetes cluster. For local testing we recommend using [minikube](https://kubernetes.io/docs/setup/learning-environment/minikube/). We also recommend using the [service catalog CLI](https://github.com/kubernetes-sigs/service-catalog/blob/master/docs/cli.md) (`svcat`) to control the service catalog.

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func startBrokerServer() {
 	router.Use(atlasbroker.AuthMiddleware(baseURL))
 
 	// Configure TLS from environment variables.
-	tlsEnabled, tlsCertFile, tlsKeyFile := getTLSConfig(logger)
+	tlsEnabled, tlsCertPath, tlsKeyPath := getTLSConfig(logger)
 
 	host := getEnvOrDefault("BROKER_HOST", DefaultServerHost)
 	port := getIntEnvOrDefault("BROKER_PORT", DefaultServerPort)
@@ -105,7 +105,7 @@ func startBrokerServer() {
 
 	var serverErr error
 	if tlsEnabled {
-		serverErr = http.ListenAndServeTLS(address, tlsCertFile, tlsKeyFile, router)
+		serverErr = http.ListenAndServeTLS(address, tlsCertPath, tlsKeyPath, router)
 	} else {
 		logger.Warn("TLS is disabled")
 		serverErr = http.ListenAndServe(address, router)
@@ -117,19 +117,18 @@ func startBrokerServer() {
 }
 
 func getTLSConfig(logger *zap.SugaredLogger) (bool, string, string) {
-	certFile := getEnvOrDefault("BROKER_TLS_CERT_FILE", "")
-	keyFile := getEnvOrDefault("BROKER_TLS_KEY_FILE", "")
+	certPath := getEnvOrDefault("BROKER_TLS_CERT_FILE", "")
+	keyPath := getEnvOrDefault("BROKER_TLS_KEY_FILE", "")
 
-	hasCertFile := certFile != ""
-	hasKeyFile := keyFile != ""
+	hasCertPath := certPath != ""
+	hasKeyPath := keyPath != ""
 
 	// Bail if only one of the cert and key has been provided.
-	if (hasCertFile && !hasKeyFile) || (!hasCertFile && hasKeyFile) {
+	if (hasCertPath && !hasKeyPath) || (!hasCertPath && hasKeyPath) {
 		logger.Fatal("Both a certificate and private key are necessary to enable TLS")
 	}
 
-	enabled := hasCertFile && hasKeyFile
-	return enabled, certFile, keyFile
+	return hasCertPath && hasKeyPath, certPath, keyPath
 }
 
 // getEnvOrPanic will try getting an environment variable and fail with a

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func startBrokerServer() {
 	if tlsEnabled {
 		serverErr = http.ListenAndServeTLS(address, tlsCertFile, tlsKeyFile, router)
 	} else {
+		logger.Warn("TLS is disabled")
 		serverErr = http.ListenAndServe(address, router)
 	}
 

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func startBrokerServer() {
 	}
 
 	if serverErr != nil {
-		logger.Fatal(err)
+		logger.Fatal(serverErr)
 	}
 }
 

--- a/samples/kubernetes/deployment.yaml
+++ b/samples/kubernetes/deployment.yaml
@@ -24,8 +24,6 @@ spec:
           env:
             - name: BROKER_HOST
               value: "0.0.0.0"
-            - name: ATLAS_BASE_URL
-              value: https://cloud-qa.mongodb.com
 
 ---
 # Service to expose the service broker inside the cluster.

--- a/samples/kubernetes/deployment.yaml
+++ b/samples/kubernetes/deployment.yaml
@@ -19,7 +19,6 @@ spec:
       containers:
         - name: atlas-service-broker
           image: quay.io/mongodb/mongodb-atlas-service-broker:latest
-          imagePullPolicy: Never
           ports:
             - containerPort: 4000
           env:


### PR DESCRIPTION
With this PR we add support for TLS to the broker API server. Users can optionally pass a certificate and private key file with environment variables.