### PR TITLE
Update E2E tests to use new basic auth credentials

### DIFF
--- a/dev/scripts/evergreen-kubernetes-setup.sh
+++ b/dev/scripts/evergreen-kubernetes-setup.sh
@@ -41,5 +41,5 @@ helm install svc-cat/catalog --name service-catalog --namespace catalog
 kubectl rollout status --watch deployment/service-catalog-catalog-apiserver --namespace=catalog
 
 echo "Add Docker image to cluster"
-# docker image tag $docker_repo/$docker_name $docker_repo/$docker_name:e2e-test
-kind load docker-image $docker_image
+docker image tag $docker_image $docker_image:e2e-test
+kind load docker-image $docker_image:e2e-test


### PR DESCRIPTION
The E2E tests were not updated when we introduced the new credentials management over basic auth. This was not caught in our tests because of a bug in the single E2E test, which has now been fixed.