### PR TITLE
CLOUDP-48940: Add testcases for e2e

### DIFF
--- a/samples/kubernetes/deployment.yaml
+++ b/samples/kubernetes/deployment.yaml
@@ -19,11 +19,14 @@ spec:
       containers:
         - name: atlas-service-broker
           image: quay.io/mongodb/mongodb-atlas-service-broker:latest
+          imagePullPolicy: Never
           ports:
             - containerPort: 4000
           env:
             - name: BROKER_HOST
               value: "0.0.0.0"
+            - name: ATLAS_BASE_URL
+              value: "https://cloud-qa.mongodb.com/"
 
 ---
 # Service to expose the service broker inside the cluster.

--- a/samples/kubernetes/used_for_e2e_tests/deploy.yaml
+++ b/samples/kubernetes/used_for_e2e_tests/deploy.yaml
@@ -24,3 +24,5 @@ spec:
           env:
             - name: BROKER_HOST
               value: "0.0.0.0"
+            - name: ATLAS_BASE_URL
+              value: "https://cloud-qa.mongodb.com/"


### PR DESCRIPTION
This pr contains test cases that will run `svcat` commands in the container to be able to verify that our service broker works as expected. This will be interacting with our atlas service broker in kubernetes. 

The e2e test executes the following operations using the `svcat` command:
- Provision 
- Update
- Deprovision
- Bind
- Unbind
